### PR TITLE
[Feature/#4] 일기 CRUD 기능 구현

### DIFF
--- a/src/main/java/LearnMate/dev/DevApplication.java
+++ b/src/main/java/LearnMate/dev/DevApplication.java
@@ -2,8 +2,10 @@ package LearnMate.dev;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DevApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/LearnMate/dev/common/BaseTimeEntity.java
+++ b/src/main/java/LearnMate/dev/common/BaseTimeEntity.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @Getter
 @MappedSuperclass
@@ -22,5 +23,10 @@ public class BaseTimeEntity {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public String getCreatedAtFormatted() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+        return createdAt.format(formatter);
+    }
 
 }

--- a/src/main/java/LearnMate/dev/common/ErrorStatus.java
+++ b/src/main/java/LearnMate/dev/common/ErrorStatus.java
@@ -35,6 +35,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _JWT_UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "JWT400", "JWT 인증 중 알 수 없는 오류가 발생했습니다."),
 
     _DUPLICATE_DIARY_DATE(HttpStatus.BAD_REQUEST, "DIARY400", "일기는 하루에 한 개만 작성할 수 있습니다."),
+    _INVALID_PATCH_DIARY(HttpStatus.BAD_REQUEST, "DIARY400", "당일 작성한 일기만 수정할 수 있습니다."),
     _INVALID_DIARY_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "DIARY400", "일기의 내용은 500자 이하여야 합니다."),
     _USER_FORBIDDEN_DIARY(HttpStatus.FORBIDDEN, "DIARY403", "다이어리에 접근 권한이 없습니다."),
     _DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY404", "해당 다이어리를 찾을 수 없습니다."),

--- a/src/main/java/LearnMate/dev/common/ErrorStatus.java
+++ b/src/main/java/LearnMate/dev/common/ErrorStatus.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 
-    // 일반 응답
     _ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT404", "해당 계정을 찾을 수 없습니다."),
     _ACCOUNT_NOT_EXIST(HttpStatus.NOT_FOUND, "ACCOUNT404", "가입되지 않은 이메일 주소입니다."),
     _ACCOUNT_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "ACCOUNT400", "이미 존재하는 계정입니다."),
@@ -18,18 +17,28 @@ public enum ErrorStatus implements BaseErrorCode {
     _SAME_PASSWORD(HttpStatus.BAD_REQUEST, "ACCOUNT400", "기존 비밀번호와 동일합니다."),
     _CERTIFIED_KEY_EXPIRED(HttpStatus.BAD_REQUEST, "ACCOUNT400", "입력 가능한 시간이 초과되었습니다."),
     _INVALID_CERTIFIED_KEY(HttpStatus.BAD_REQUEST, "ACCOUNT400", "인증 번호가 일치하지 않습니다."),
+
+    // 일반 응답
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증되지 않은 요청입니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "접근 권한이 없습니다."),
+    _UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "알 수 없는 오류가 발생했습니다."),
+
     _FILE_DOWNLOAD_FAILED(HttpStatus.BAD_REQUEST, "FILE404", "파일을 다운받을 수 없습니다."),
     _EMAIL_SEND_FAIL(HttpStatus.BAD_REQUEST, "EMAIL400", "이메일 전송에 실패했습니다."),
+
     _JWT_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT404", "토큰을 찾을 수 없습니다"),
     _JWT_INVALID(HttpStatus.UNAUTHORIZED, "JWT400", "유효하지 않는 토큰입니다"),
     _JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT400", "만료된 토큰입니다"),
     _JWT_BLACKLIST(HttpStatus.UNAUTHORIZED, "JWT400", "접근 불가능한 토큰입니다"),
     _JWT_UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "JWT400", "JWT 인증 중 알 수 없는 오류가 발생했습니다."),
-    _UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "알 수 없는 오류가 발생했습니다.");
+
+    _DUPLICATE_DIARY_DATE(HttpStatus.BAD_REQUEST, "DIARY400", "일기는 하루에 한 개만 작성할 수 있습니다."),
+    _INVALID_DIARY_CONTENT_LENGTH(HttpStatus.BAD_REQUEST, "DIARY400", "일기의 내용은 500자 이하여야 합니다."),
+    _USER_FORBIDDEN_DIARY(HttpStatus.FORBIDDEN, "DIARY403", "다이어리에 접근 권한이 없습니다."),
+    _DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY404", "해당 다이어리를 찾을 수 없습니다."),
+    ;
 
 
 

--- a/src/main/java/LearnMate/dev/controller/DiaryController.java
+++ b/src/main/java/LearnMate/dev/controller/DiaryController.java
@@ -34,4 +34,15 @@ public class DiaryController {
         return ApiResponse.onSuccessData("일기 수정 성공", diaryService.patchDiary(1L, request));
 
     }
+
+    @DeleteMapping("/{diaryId}")
+    public ApiResponse deleteDiary(
+            // TODO: get user info from session
+//            @SessionAttribute(name = "user_id") Long userId,
+            @PathVariable(value = "diaryId") Long diaryId) {
+
+        diaryService.deleteDiary(1L, diaryId);
+        return ApiResponse.onSuccess("일기 삭제 성공");
+
+    }
 }

--- a/src/main/java/LearnMate/dev/controller/DiaryController.java
+++ b/src/main/java/LearnMate/dev/controller/DiaryController.java
@@ -1,0 +1,26 @@
+package LearnMate.dev.controller;
+
+import LearnMate.dev.common.ApiResponse;
+import LearnMate.dev.model.dto.request.DiaryPostRequest;
+import LearnMate.dev.service.DiaryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/diary")
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @PostMapping("")
+    public ApiResponse<Long> postDiary(
+            // TODO: get user info from session
+//            @SessionAttribute(name = "user_id") Long userId,
+            @RequestBody @Valid DiaryPostRequest request) {
+
+        return ApiResponse.onSuccessData("일기 작성 성공", diaryService.postDiary(1L, request));
+
+    }
+}

--- a/src/main/java/LearnMate/dev/controller/DiaryController.java
+++ b/src/main/java/LearnMate/dev/controller/DiaryController.java
@@ -3,6 +3,7 @@ package LearnMate.dev.controller;
 import LearnMate.dev.common.ApiResponse;
 import LearnMate.dev.model.dto.request.DiaryPatchRequest;
 import LearnMate.dev.model.dto.request.DiaryPostRequest;
+import LearnMate.dev.model.dto.response.DiaryDetailResponse;
 import LearnMate.dev.service.DiaryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,16 @@ public class DiaryController {
 
         diaryService.deleteDiary(1L, diaryId);
         return ApiResponse.onSuccess("일기 삭제 성공");
+
+    }
+
+    @GetMapping("/{diaryId}")
+    public ApiResponse<DiaryDetailResponse> getDiaryDetail(
+            // TODO: get user info from session
+//            @SessionAttribute(name = "user_id") Long userId,
+            @PathVariable(value = "diaryId") Long diaryId) {
+
+        return ApiResponse.onSuccessData("일기 상세 조회 성공", diaryService.getDiaryDetail(1L, diaryId));
 
     }
 }

--- a/src/main/java/LearnMate/dev/controller/DiaryController.java
+++ b/src/main/java/LearnMate/dev/controller/DiaryController.java
@@ -1,6 +1,7 @@
 package LearnMate.dev.controller;
 
 import LearnMate.dev.common.ApiResponse;
+import LearnMate.dev.model.dto.request.DiaryPatchRequest;
 import LearnMate.dev.model.dto.request.DiaryPostRequest;
 import LearnMate.dev.service.DiaryService;
 import jakarta.validation.Valid;
@@ -21,6 +22,16 @@ public class DiaryController {
             @RequestBody @Valid DiaryPostRequest request) {
 
         return ApiResponse.onSuccessData("일기 작성 성공", diaryService.postDiary(1L, request));
+
+    }
+
+    @PatchMapping("")
+    public ApiResponse<Long> patchDiary(
+            // TODO: get user info from session
+//            @SessionAttribute(name = "user_id") Long userId,
+            @RequestBody @Valid DiaryPatchRequest request ) {
+
+        return ApiResponse.onSuccessData("일기 수정 성공", diaryService.patchDiary(1L, request));
 
     }
 }

--- a/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
@@ -1,0 +1,20 @@
+package LearnMate.dev.model.converter;
+
+import LearnMate.dev.model.entity.ActionTip;
+import LearnMate.dev.model.entity.Diary;
+import LearnMate.dev.model.entity.Emotion;
+import LearnMate.dev.model.entity.User;
+
+public class DiaryConverter {
+
+    public static Diary toDiary(String content, User user, Emotion emotion, ActionTip actionTip) {
+        return Diary.builder()
+                .content(content)
+                .user(user)
+                .emotion(emotion)
+                .actionTip(actionTip)
+                .build();
+    }
+
+
+}

--- a/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
@@ -1,5 +1,6 @@
 package LearnMate.dev.model.converter;
 
+import LearnMate.dev.model.dto.response.DiaryDetailResponse;
 import LearnMate.dev.model.entity.ActionTip;
 import LearnMate.dev.model.entity.Diary;
 import LearnMate.dev.model.entity.Emotion;
@@ -13,6 +14,15 @@ public class DiaryConverter {
                 .user(user)
                 .emotion(emotion)
                 .actionTip(actionTip)
+                .build();
+    }
+
+    public static DiaryDetailResponse toDiaryDetailResponse(Diary diary) {
+        return DiaryDetailResponse.builder()
+                .date(diary.getCreatedAtFormatted())
+                .content(diary.getContent())
+                .emotion(diary.getEmotion().getEmotion().getValue())
+                .actionTip(diary.getActionTip().getContent())
                 .build();
     }
 

--- a/src/main/java/LearnMate/dev/model/dto/request/DiaryPatchRequest.java
+++ b/src/main/java/LearnMate/dev/model/dto/request/DiaryPatchRequest.java
@@ -1,0 +1,17 @@
+package LearnMate.dev.model.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DiaryPatchRequest {
+
+    @NotNull(message = "수정할 일기의 id를 입력해주세요.")
+    private Long diaryId;
+
+    @NotBlank(message = "수정할 일기 내용을 입력해주세요.")
+    private String content;
+}

--- a/src/main/java/LearnMate/dev/model/dto/request/DiaryPostRequest.java
+++ b/src/main/java/LearnMate/dev/model/dto/request/DiaryPostRequest.java
@@ -1,0 +1,14 @@
+package LearnMate.dev.model.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DiaryPostRequest {
+
+    @NotBlank(message = "일기 내용을 입력해주세요.")
+    private String content;
+
+}

--- a/src/main/java/LearnMate/dev/model/dto/response/DiaryDetailResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/DiaryDetailResponse.java
@@ -1,0 +1,19 @@
+package LearnMate.dev.model.dto.response;
+
+import LearnMate.dev.model.enums.EmotionSpectrum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DiaryDetailResponse {
+
+    private String date;
+    private String content;
+    private String emotion; // 감정 지표
+    private String actionTip;
+
+}

--- a/src/main/java/LearnMate/dev/model/entity/ActionTip.java
+++ b/src/main/java/LearnMate/dev/model/entity/ActionTip.java
@@ -1,0 +1,25 @@
+package LearnMate.dev.model.entity;
+
+import LearnMate.dev.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "actiontips")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActionTip extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "action_tip_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+}

--- a/src/main/java/LearnMate/dev/model/entity/Diary.java
+++ b/src/main/java/LearnMate/dev/model/entity/Diary.java
@@ -1,0 +1,32 @@
+package LearnMate.dev.model.entity;
+
+import LearnMate.dev.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "diaries")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diary_id")
+    private Long id;
+
+    @Column(length = 500, nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL)
+    private Emotion emotion;
+
+    @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL)
+    private ActionTip actionTip;
+
+}

--- a/src/main/java/LearnMate/dev/model/entity/Diary.java
+++ b/src/main/java/LearnMate/dev/model/entity/Diary.java
@@ -2,13 +2,12 @@ package LearnMate.dev.model.entity;
 
 import LearnMate.dev.common.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
-@Getter
+@Getter @Builder
 @Table(name = "diaries")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Diary extends BaseTimeEntity {
     @Id

--- a/src/main/java/LearnMate/dev/model/entity/Diary.java
+++ b/src/main/java/LearnMate/dev/model/entity/Diary.java
@@ -28,4 +28,10 @@ public class Diary extends BaseTimeEntity {
     @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL)
     private ActionTip actionTip;
 
+    public void updateContent(String content) {
+        if (!content.isEmpty()) {
+            this.content = content;
+        }
+    }
+
 }

--- a/src/main/java/LearnMate/dev/model/entity/Emotion.java
+++ b/src/main/java/LearnMate/dev/model/entity/Emotion.java
@@ -1,0 +1,33 @@
+package LearnMate.dev.model.entity;
+
+import LearnMate.dev.model.enums.EmotionSpectrum;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "emotions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Emotion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "emotion_id")
+    private Long id;
+
+    @Column(length = 500, nullable = false)
+    private Double score; // 감정 점수
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmotionSpectrum emotion; // 감정 지표
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+}

--- a/src/main/java/LearnMate/dev/model/entity/Plan.java
+++ b/src/main/java/LearnMate/dev/model/entity/Plan.java
@@ -1,0 +1,28 @@
+package LearnMate.dev.model.entity;
+
+import LearnMate.dev.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "plans")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Plan extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
+    private Long id;
+
+    @Column(length = 300, nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String guide;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/LearnMate/dev/model/entity/Report.java
+++ b/src/main/java/LearnMate/dev/model/entity/Report.java
@@ -1,0 +1,28 @@
+package LearnMate.dev.model.entity;
+
+import LearnMate.dev.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "reports")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL)
+    private List<Emotion> emotionList;
+
+}

--- a/src/main/java/LearnMate/dev/model/entity/User.java
+++ b/src/main/java/LearnMate/dev/model/entity/User.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @Getter
 @Table(name = "users")
@@ -26,6 +28,16 @@ public class User extends BaseTimeEntity {
 
     @Column(name = "user_password", nullable = false)
     private String password;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Report> reportList;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Diary> diaryList;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Plan> planList;
+
 
     @Builder
     public User(String name, String loginId, String password) {

--- a/src/main/java/LearnMate/dev/model/enums/EmotionSpectrum.java
+++ b/src/main/java/LearnMate/dev/model/enums/EmotionSpectrum.java
@@ -1,0 +1,17 @@
+package LearnMate.dev.model.enums;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum EmotionSpectrum {
+
+    ANGRY("화남"), SAD("슬픔"), ANNOYING("짜증"),
+    SOSO("보통"), HAPPY("행복"), DELIGHT("기쁨"), EXCITING("신남") ;
+
+    public final String value;
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/src/main/java/LearnMate/dev/repository/DiaryRepository.java
+++ b/src/main/java/LearnMate/dev/repository/DiaryRepository.java
@@ -1,0 +1,9 @@
+package LearnMate.dev.repository;
+
+import LearnMate.dev.model.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+}

--- a/src/main/java/LearnMate/dev/repository/DiaryRepository.java
+++ b/src/main/java/LearnMate/dev/repository/DiaryRepository.java
@@ -1,9 +1,22 @@
 package LearnMate.dev.repository;
 
 import LearnMate.dev.model.entity.Diary;
+import LearnMate.dev.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    @Query("SELECT COUNT(d) > 0 " +
+            "FROM Diary d " +
+            "WHERE d.user = :user " +
+            "AND DATE(d.createdAt) = :created_at")
+    boolean existsDiaryByCreatedAt(
+            @Param(value = "user") User user,
+            @Param(value = "created_at") LocalDate localDate);
 }

--- a/src/main/java/LearnMate/dev/security/security/SecurityConfig.java
+++ b/src/main/java/LearnMate/dev/security/security/SecurityConfig.java
@@ -35,12 +35,8 @@ public class SecurityConfig {
 
     // 공개 URL
     private static final String[] PUBLIC_URLS = {
-            "/api/v1/accounts/sendEmailConfirm",
-            "/api/v1/accounts/verifyCode",
-            "/api/v1/accounts/signUp",
-            "/api/v1/accounts/signIn",
-            "/api/v1/accounts/checkEmail",
-            "/api/v1/accounts/sendPasswordChangeEmail",
+            "/api/v1/users/signUp",
+            "/api/v1/users/signIn",
     };
 
     private static final String[] WHITE_LIST_URL = {

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -5,6 +5,7 @@ import LearnMate.dev.common.ErrorStatus;
 import LearnMate.dev.model.converter.DiaryConverter;
 import LearnMate.dev.model.dto.request.DiaryPatchRequest;
 import LearnMate.dev.model.dto.request.DiaryPostRequest;
+import LearnMate.dev.model.dto.response.DiaryDetailResponse;
 import LearnMate.dev.model.entity.Diary;
 import LearnMate.dev.model.entity.User;
 import LearnMate.dev.repository.DiaryRepository;
@@ -68,6 +69,8 @@ public class DiaryService {
         // content 정보 수정
         diary.updateContent(content);
 
+        // TODO: 감정 분석 API 호출
+
         // TODO: 일기 및 감정 분석 상세 조회로 변경
         return diary.getId();
     }
@@ -86,6 +89,21 @@ public class DiaryService {
 
         // TODO: EMOTION, ACTIONTIP CASCADE
         diaryRepository.delete(diary);
+    }
+
+    /*
+     * diary 작성 날짜, 내용, 감정 지표, 행동 요령 등 상세 정보를 반환
+     * @param userId
+     * @param diaryId
+     * @return
+     */
+    public DiaryDetailResponse getDiaryDetail(Long userId, Long diaryId) {
+        // user - diary 권한 검사
+        User user = findUserById(userId);
+        Diary diary = findDiaryById(diaryId);
+        validIsUserAuthorizedForDiary(user, diary);
+
+        return DiaryConverter.toDiaryDetailResponse(diary);
     }
 
     private void validIsUserPostDiary(User user) {

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -58,6 +58,9 @@ public class DiaryService {
         Diary diary = findDiaryById(request.getDiaryId());
         validIsUserAuthorizedForDiary(user, diary);
 
+        // 일기 작성 날짜 검사
+        validDiaryCreatedAt(diary);
+
         // content 길이 검사
         String content = request.getContent();
         validContentLength(content);
@@ -67,6 +70,22 @@ public class DiaryService {
 
         // TODO: 일기 및 감정 분석 상세 조회로 변경
         return diary.getId();
+    }
+
+    /*
+     * diaryId를 param으로 받아, diary, emotion, actiontip 객체 제거
+     * @param userId
+     * @param diaryId
+     */
+    @Transactional
+    public void deleteDiary(Long userId, Long diaryId) {
+        // user - diary 권한 검사
+        User user = findUserById(userId);
+        Diary diary = findDiaryById(diaryId);
+        validIsUserAuthorizedForDiary(user, diary);
+
+        // TODO: EMOTION, ACTIONTIP CASCADE
+        diaryRepository.delete(diary);
     }
 
     private void validIsUserPostDiary(User user) {
@@ -82,6 +101,11 @@ public class DiaryService {
     private void validIsUserAuthorizedForDiary(User user, Diary diary) {
         if (!diary.getUser().equals(user))
             throw new ApiException(ErrorStatus._USER_FORBIDDEN_DIARY);
+    }
+
+    private void validDiaryCreatedAt(Diary diary) {
+        if (diary.getCreatedAt().toLocalDate().equals(LocalDate.now()))
+            throw new ApiException(ErrorStatus._INVALID_PATCH_DIARY);
     }
 
     private User findUserById(Long userId) {

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -1,0 +1,36 @@
+package LearnMate.dev.service;
+
+import LearnMate.dev.common.ApiException;
+import LearnMate.dev.common.ErrorStatus;
+import LearnMate.dev.model.converter.DiaryConverter;
+import LearnMate.dev.model.dto.request.DiaryPostRequest;
+import LearnMate.dev.model.entity.Diary;
+import LearnMate.dev.model.entity.User;
+import LearnMate.dev.repository.DiaryRepository;
+import LearnMate.dev.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+    private final UserRepository userRepository;
+    private final DiaryRepository diaryRepository;
+
+    public Long postDiary(Long userId, DiaryPostRequest request) {
+        User user = findUserById(userId);
+
+        // TODO: GPT API 연결 및 EMOTION, ACTIONTIP ENTITY 저장 수정
+        Diary diary = DiaryConverter.toDiary(request.getContent(), user, null, null);
+        diaryRepository.save(diary);
+
+        // TODO: 일기 및 감정 분석 상세 조회로 변경
+        return diary.getId();
+    }
+
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._ACCOUNT_NOT_FOUND));
+    }
+}

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -3,6 +3,7 @@ package LearnMate.dev.service;
 import LearnMate.dev.common.ApiException;
 import LearnMate.dev.common.ErrorStatus;
 import LearnMate.dev.model.converter.DiaryConverter;
+import LearnMate.dev.model.dto.request.DiaryPatchRequest;
 import LearnMate.dev.model.dto.request.DiaryPostRequest;
 import LearnMate.dev.model.entity.Diary;
 import LearnMate.dev.model.entity.User;
@@ -10,15 +11,31 @@ import LearnMate.dev.repository.DiaryRepository;
 import LearnMate.dev.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class DiaryService {
     private final UserRepository userRepository;
     private final DiaryRepository diaryRepository;
 
+    /*
+     * content를 받아 일기를 작성
+     * @param userId
+     * @param request
+     * @return
+     */
+    @Transactional
     public Long postDiary(Long userId, DiaryPostRequest request) {
         User user = findUserById(userId);
+        validIsUserPostDiary(user);
+
+        // content 길이 검사
+        String content = request.getContent();
+        validContentLength(content);
 
         // TODO: GPT API 연결 및 EMOTION, ACTIONTIP ENTITY 저장 수정
         Diary diary = DiaryConverter.toDiary(request.getContent(), user, null, null);
@@ -28,9 +45,52 @@ public class DiaryService {
         return diary.getId();
     }
 
+    /*
+     * content, diaryId를 받아 해당 일기의 내용을 수정 후 일기 상세 정보를 반환
+     * @param userId
+     * @param request
+     * @return
+     */
+    @Transactional
+    public Long patchDiary(Long userId, DiaryPatchRequest request) {
+        // user - diary 권한 검사
+        User user = findUserById(userId);
+        Diary diary = findDiaryById(request.getDiaryId());
+        validIsUserAuthorizedForDiary(user, diary);
+
+        // content 길이 검사
+        String content = request.getContent();
+        validContentLength(content);
+
+        // content 정보 수정
+        diary.updateContent(content);
+
+        // TODO: 일기 및 감정 분석 상세 조회로 변경
+        return diary.getId();
+    }
+
+    private void validIsUserPostDiary(User user) {
+        if (diaryRepository.existsDiaryByCreatedAt(user, LocalDate.now()))
+            throw new ApiException(ErrorStatus._DUPLICATE_DIARY_DATE);
+    }
+
+    private void validContentLength(String content) {
+        if (content.length() > 500)
+            throw new ApiException(ErrorStatus._INVALID_DIARY_CONTENT_LENGTH);
+    }
+
+    private void validIsUserAuthorizedForDiary(User user, Diary diary) {
+        if (!diary.getUser().equals(user))
+            throw new ApiException(ErrorStatus._USER_FORBIDDEN_DIARY);
+    }
 
     private User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(ErrorStatus._ACCOUNT_NOT_FOUND));
+    }
+
+    private Diary findDiaryById(Long diaryId) {
+        return diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new ApiException(ErrorStatus._DIARY_NOT_FOUND));
     }
 }

--- a/src/main/java/LearnMate/dev/service/UserService.java
+++ b/src/main/java/LearnMate/dev/service/UserService.java
@@ -23,6 +23,7 @@ public class UserService {
 
     private final UserRepository userRepository;
 
+    @Transactional
     public String signUp(UserSignUpRequest request) {
         if (userRepository.findUserByLoginId(request.getLoginId()) != null) {
             throw new ApiException(ErrorStatus._ACCOUNT_ALREADY_EXIST);


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #4 

### 💡 작업내용
- **Entity 파일 작성 및 연관관계 설정**
  - Diary, Emotion, ActionTip, Plan, Report 
- **일기 작성 기능 임시 구현**
  - 500자 이하의 content를 받아 일기 작성
  - 작성 후 감정 분석 및 행동 요령 제안 API 추후 연결 필요
- **일기 수정 기능 구현**
  - 당일 작성한 일기만 수정 가능
  - user-diary 간의 권한 검사 
- **일기 삭제 기능 구현**
  - Emotion, ActionTip data CASCADE  
- **일기 상세 조회 기능 구현**
  - emotion, actionTip의 content 함께 조회 

### 📸 스크린샷(선택)
<img width="889" alt="스크린샷 2024-11-06 오후 4 50 44" src="https://github.com/user-attachments/assets/c7cedc6b-3624-41ae-9c8a-5dd31e3998f0">
<img width="486" alt="스크린샷 2024-11-06 오후 5 38 56" src="https://github.com/user-attachments/assets/435b8651-984c-41a6-948b-d4281d0e7431">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
- controller에서 Session으로 jwt token 받아오는 법을 잘 모르겠어서 우선 주석 처리 해두었습니다! 추후 수정하겠습니다
