### PR TITLE
[Feature/#7] 텍스트 기반 감정 분석 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
 	// json
 	implementation 'org.json:json:20230227'
+
+	// google natural language
+	implementation 'com.google.cloud:google-cloud-language:2.53.0'
 }
 
 jib {

--- a/src/main/java/LearnMate/dev/common/ErrorStatus.java
+++ b/src/main/java/LearnMate/dev/common/ErrorStatus.java
@@ -43,7 +43,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Emotion
     _INVALID_EMOTION_SCORE(HttpStatus.BAD_REQUEST, "EMOTION400", "감정 점수는 -1과 1 사이여야 합니다."),
-    _INVALID_EMOTION_SPECTRUN(HttpStatus.BAD_REQUEST, "EMOTION400", "유효하지 않은 감정 지표입니다.")
+    _INVALID_EMOTION_SPECTRUN(HttpStatus.BAD_REQUEST, "EMOTION400", "유효하지 않은 감정 지표입니다."),
+    _ANALYZE_EMOTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EMOTION500", "감정 분석 API 호출 중 오류가 발생했습니다.")
     ;
 
 

--- a/src/main/java/LearnMate/dev/common/config/AsyncConfig.java
+++ b/src/main/java/LearnMate/dev/common/config/AsyncConfig.java
@@ -1,0 +1,33 @@
+package LearnMate.dev.common.config;
+
+import LearnMate.dev.common.exception.CustomAsyncUncaughtExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(5);
+        executor.setKeepAliveSeconds(30);
+        executor.setThreadNamePrefix("async-executor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new CustomAsyncUncaughtExceptionHandler();
+    }
+
+}

--- a/src/main/java/LearnMate/dev/common/config/GoogleNaturalLanguageConfig.java
+++ b/src/main/java/LearnMate/dev/common/config/GoogleNaturalLanguageConfig.java
@@ -1,0 +1,28 @@
+package LearnMate.dev.common.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.language.v1.LanguageServiceSettings;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+
+@Configuration
+public class GoogleNaturalLanguageConfig {
+    @Value("classpath:nlp.json")
+    Resource gcsCredentials;
+
+    @Bean
+    public LanguageServiceSettings languageServiceSettings() {
+        try {
+            return LanguageServiceSettings.newBuilder()
+                    .setCredentialsProvider(() ->
+                            GoogleCredentials.fromStream(gcsCredentials.getInputStream()))
+                    .build();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to initialize LanguageServiceSettings", e);
+        }
+    }
+}

--- a/src/main/java/LearnMate/dev/common/exception/ApiException.java
+++ b/src/main/java/LearnMate/dev/common/exception/ApiException.java
@@ -1,5 +1,6 @@
-package LearnMate.dev.common;
+package LearnMate.dev.common.exception;
 
+import LearnMate.dev.common.ErrorStatus;
 import LearnMate.dev.model.dto.ErrorReasonDto;
 import lombok.Getter;
 

--- a/src/main/java/LearnMate/dev/common/exception/CustomAsyncUncaughtExceptionHandler.java
+++ b/src/main/java/LearnMate/dev/common/exception/CustomAsyncUncaughtExceptionHandler.java
@@ -1,0 +1,17 @@
+package LearnMate.dev.common.exception;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+
+public class CustomAsyncUncaughtExceptionHandler implements AsyncUncaughtExceptionHandler {
+    @Override
+    public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+        System.out.println("Exception message - " + ex.getMessage());
+        System.out.println("Method name - " + method.getName());
+
+        for (Object param : params) {
+            System.out.println("Parameter value - " + param);
+        }
+    }
+}

--- a/src/main/java/LearnMate/dev/common/exception/ExceptionAdvice.java
+++ b/src/main/java/LearnMate/dev/common/exception/ExceptionAdvice.java
@@ -1,5 +1,7 @@
-package LearnMate.dev.common;
+package LearnMate.dev.common.exception;
 
+import LearnMate.dev.common.ApiResponse;
+import LearnMate.dev.common.ErrorStatus;
 import LearnMate.dev.model.dto.ErrorReasonDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;

--- a/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
@@ -28,7 +28,7 @@ public class DiaryConverter {
                 .build();
     }
 
-    public static DiaryAnalysisResponse toDiaryAnalysisResponse(Double score, String actionTip) {
+    public static DiaryAnalysisResponse toDiaryAnalysisResponse(Float score, String actionTip) {
         return DiaryAnalysisResponse.builder()
                 .emotionScore(score)
                 .actionTip(actionTip)

--- a/src/main/java/LearnMate/dev/model/dto/response/DiaryAnalysisResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/DiaryAnalysisResponse.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DiaryAnalysisResponse {
 
-    private Double emotionScore;
+    private Float emotionScore;
     private String actionTip;
 
 }

--- a/src/main/java/LearnMate/dev/service/ActionTipService.java
+++ b/src/main/java/LearnMate/dev/service/ActionTipService.java
@@ -1,0 +1,17 @@
+package LearnMate.dev.service;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class ActionTipService {
+
+    @Async
+    public CompletableFuture<String> getActionTip(String content) {
+        String text = "Action Tip";
+
+        return CompletableFuture.completedFuture(text);
+    }
+}

--- a/src/main/java/LearnMate/dev/service/NaturalLanguageService.java
+++ b/src/main/java/LearnMate/dev/service/NaturalLanguageService.java
@@ -1,0 +1,37 @@
+package LearnMate.dev.service;
+
+import LearnMate.dev.common.exception.ApiException;
+import LearnMate.dev.common.ErrorStatus;
+import com.google.cloud.language.v1.Document;
+import com.google.cloud.language.v1.LanguageServiceClient;
+import com.google.cloud.language.v1.Sentiment;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class NaturalLanguageService {
+
+    /*
+     * cloud Natural Language API를 호출해 텍스트에 대한 감정을 분석
+     * @param text
+     * @return
+     */
+    @Async
+    public CompletableFuture<Float> analyzeEmotion(String text) {
+        try (LanguageServiceClient language = LanguageServiceClient.create()) {
+
+            Document doc = Document.newBuilder().setContent(text).setType(Document.Type.PLAIN_TEXT).build();
+            Sentiment sentiment = language.analyzeSentiment(doc).getDocumentSentiment();
+
+            System.out.printf("Text: %s%n", text);
+            System.out.printf("Sentiment: %s, %s%n", sentiment.getScore(), sentiment.getMagnitude());
+
+            return CompletableFuture.completedFuture(sentiment.getScore());
+        } catch (IOException e) {
+            throw new ApiException(ErrorStatus._ANALYZE_EMOTION_ERROR);
+        }
+    }
+}

--- a/src/main/java/LearnMate/dev/service/UserService.java
+++ b/src/main/java/LearnMate/dev/service/UserService.java
@@ -1,6 +1,6 @@
 package LearnMate.dev.service;
 
-import LearnMate.dev.common.ApiException;
+import LearnMate.dev.common.exception.ApiException;
 import LearnMate.dev.common.ErrorStatus;
 import LearnMate.dev.model.dto.request.UserSignInRequest;
 import LearnMate.dev.model.dto.request.UserSignUpRequest;


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #7 

### 💡 작업내용
- google cloud natural language API 연결
  - 계정 Json key를 이용해 API 사용
- text에 대한 감정 점수 (-1~1) 반환
  - 음수일 시 부정적인 감정
  - 양수일 시 긍정적인 감정
- `@Async`를 이용한 비동기 처리 적용

### 📸 스크린샷(선택)
<img width="805" alt="스크린샷 2024-11-09 오전 2 08 24" src="https://github.com/user-attachments/assets/eab881b8-5b5a-433e-8c21-19f7bc48367b">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
