### PR TITLE
[Feature/#16] 감정 분석 레포트 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ out/
 
 ### nlp.json
 src/main/resources/nlp.json
+
+### prompt
+src/main/resources/*.txt

--- a/src/main/java/LearnMate/dev/controller/ReportController.java
+++ b/src/main/java/LearnMate/dev/controller/ReportController.java
@@ -1,0 +1,20 @@
+package LearnMate.dev.controller;
+
+import LearnMate.dev.common.ApiResponse;
+import LearnMate.dev.model.dto.response.ReportResponse;
+import LearnMate.dev.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/report")
+public class ReportController {
+    private final ReportService reportService;
+    @GetMapping()
+    public ApiResponse<ReportResponse.ReportDto> getEmotionReport() {
+        return ApiResponse.onSuccessData("감정 분석 레포트 조회 성공", reportService.getEmotionReport());
+    }
+}

--- a/src/main/java/LearnMate/dev/model/converter/ReportConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/ReportConverter.java
@@ -6,9 +6,21 @@ import java.util.List;
 
 public class ReportConverter {
 
+    public static ReportResponse.ReportEmotionDto toReportEmotionDto(ReportResponse.EmotionDto emotionDto) {
+        return ReportResponse.ReportEmotionDto.builder()
+                .emotion(emotionDto.getEmotionSpectrum().getValue())
+                .emoticon(emotionDto.getEmotionSpectrum().getEmoticon())
+                .count(emotionDto.getCount())
+                .build();
+    }
     public static ReportResponse.ReportDto toReportDto(List<ReportResponse.EmotionDto> emotionDtoList) {
+
+        List<ReportResponse.ReportEmotionDto> reportEmotionDtoList = emotionDtoList.stream()
+                .map(ReportConverter::toReportEmotionDto)
+                .toList();
+
         return ReportResponse.ReportDto.builder()
-                .emotionReport(emotionDtoList)
+                .emotionReport(reportEmotionDtoList)
                 .build();
     }
 

--- a/src/main/java/LearnMate/dev/model/converter/ReportConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/ReportConverter.java
@@ -1,0 +1,15 @@
+package LearnMate.dev.model.converter;
+
+import LearnMate.dev.model.dto.response.ReportResponse;
+
+import java.util.List;
+
+public class ReportConverter {
+
+    public static ReportResponse.ReportDto toReportDto(List<ReportResponse.EmotionDto> emotionDtoList) {
+        return ReportResponse.ReportDto.builder()
+                .emotionReport(emotionDtoList)
+                .build();
+    }
+
+}

--- a/src/main/java/LearnMate/dev/model/dto/response/ReportResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/ReportResponse.java
@@ -16,14 +16,12 @@ public class ReportResponse {
     @NoArgsConstructor
     public static class EmotionDto {
 
-        private String emotion;
-        private String emoticon;
+        private EmotionSpectrum emotionSpectrum;
         private Long count;
         private int order;
 
         public EmotionDto(EmotionSpectrum emotion, Long count) {
-            this.emotion = emotion.getValue();
-            this.emoticon = emotion.getEmoticon();
+            this.emotionSpectrum = emotion;
             this.count = count == null ? 0 : count;
             this.order = emotion.getOrder();
         }
@@ -33,9 +31,21 @@ public class ReportResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class ReportEmotionDto {
+
+        private String emotion;
+        private String emoticon;
+        private Long count;
+
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class ReportDto {
 
-        private List<EmotionDto> emotionReport;
+        private List<ReportEmotionDto> emotionReport;
 
     }
 

--- a/src/main/java/LearnMate/dev/model/dto/response/ReportResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/ReportResponse.java
@@ -1,0 +1,44 @@
+package LearnMate.dev.model.dto.response;
+
+import LearnMate.dev.model.enums.EmotionSpectrum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class ReportResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class EmotionDto {
+
+        private String emotion;
+        private String emoticon;
+        private Long count;
+        private int order;
+
+        public EmotionDto(EmotionSpectrum emotion, Long count) {
+            this.emotion = emotion.getValue();
+            this.emoticon = emotion.getEmoticon();
+            this.count = count == null ? 0 : count;
+            this.order = emotion.getOrder();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ReportDto {
+
+        private List<EmotionDto> emotionReport;
+
+    }
+
+}
+
+

--- a/src/main/java/LearnMate/dev/model/entity/Emotion.java
+++ b/src/main/java/LearnMate/dev/model/entity/Emotion.java
@@ -1,5 +1,6 @@
 package LearnMate.dev.model.entity;
 
+import LearnMate.dev.common.BaseTimeEntity;
 import LearnMate.dev.model.enums.EmotionSpectrum;
 import jakarta.persistence.*;
 import lombok.*;
@@ -9,7 +10,7 @@ import lombok.*;
 @Table(name = "emotions")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Emotion {
+public class Emotion extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "emotion_id")

--- a/src/main/java/LearnMate/dev/model/entity/Report.java
+++ b/src/main/java/LearnMate/dev/model/entity/Report.java
@@ -2,15 +2,14 @@ package LearnMate.dev.model.entity;
 
 import LearnMate.dev.common.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 @Entity
-@Getter
+@Getter @Builder
 @Table(name = "reports")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseTimeEntity {
     @Id

--- a/src/main/java/LearnMate/dev/model/enums/EmotionSpectrum.java
+++ b/src/main/java/LearnMate/dev/model/enums/EmotionSpectrum.java
@@ -6,12 +6,13 @@ import lombok.Getter;
 @AllArgsConstructor @Getter
 public enum EmotionSpectrum {
 
-    HAPPY("행복", "🥰"), DELIGHT("기쁨", "🥳"), EXCITING("신남", "😝"),
-    SOSO("보통", "😐"),
-    ANNOYING("짜증", "😫"), SAD("슬픔", "😢"), ANGRY("화남", "😡");
+    HAPPY("행복", "🥰", 1), DELIGHT("기쁨", "🥳", 2), EXCITING("신남", "😝", 3),
+    SOSO("보통", "😐", 4),
+    ANNOYING("짜증", "😫", 5), SAD("슬픔", "😢", 6), ANGRY("화남", "😡", 7);
 
     public final String value;
     public final String emoticon;
+    public final int order;
 
     public static EmotionSpectrum getName(String value){
         for (EmotionSpectrum emotion : EmotionSpectrum.values()) {

--- a/src/main/java/LearnMate/dev/repository/EmotionRepository.java
+++ b/src/main/java/LearnMate/dev/repository/EmotionRepository.java
@@ -1,7 +1,26 @@
 package LearnMate.dev.repository;
 
+import LearnMate.dev.model.dto.response.ReportResponse;
 import LearnMate.dev.model.entity.Emotion;
+import LearnMate.dev.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface EmotionRepository extends JpaRepository<Emotion, Long> {
+
+    @Query("SELECT new LearnMate.dev.model.dto.response.ReportResponse$EmotionDto(e.emotion, COUNT(e)) " +
+            "FROM Emotion e " +
+            "JOIN e.diary d " +
+            "WHERE d.user = :user " +
+            "AND DATE(e.createdAt) >= :startDate " +
+            "AND DATE(e.createdAt) <= :endDate " +
+            "GROUP BY e.emotion ")
+    List<ReportResponse.EmotionDto> findEmotionDtoByUser(
+            @Param(value = "startDate") LocalDate startDate,
+            @Param(value = "endDate") LocalDate endDate,
+            @Param(value = "user") User user);
 }

--- a/src/main/java/LearnMate/dev/service/PlanService.java
+++ b/src/main/java/LearnMate/dev/service/PlanService.java
@@ -6,7 +6,6 @@ import LearnMate.dev.model.converter.PlanConverter;
 import LearnMate.dev.model.dto.request.PlanPostRequest;
 import LearnMate.dev.model.dto.request.PlanPatchRequest;
 import LearnMate.dev.model.dto.response.PlanDetailResponse;
-import LearnMate.dev.model.entity.Diary;
 import LearnMate.dev.model.entity.Plan;
 import LearnMate.dev.model.entity.User;
 import LearnMate.dev.repository.PlanRepository;

--- a/src/main/java/LearnMate/dev/service/ReportService.java
+++ b/src/main/java/LearnMate/dev/service/ReportService.java
@@ -1,0 +1,62 @@
+package LearnMate.dev.service;
+
+import LearnMate.dev.common.ErrorStatus;
+import LearnMate.dev.common.exception.ApiException;
+import LearnMate.dev.model.converter.ReportConverter;
+import LearnMate.dev.model.dto.response.ReportResponse;
+import LearnMate.dev.model.entity.User;
+import LearnMate.dev.repository.EmotionRepository;
+import LearnMate.dev.repository.UserRepository;
+import LearnMate.dev.security.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+    private final UserRepository userRepository;
+    private final EmotionRepository emotionRepository;
+
+
+    /*
+     * user가 2주동안 겪은 각 감정의 개수를 리스트 형태로 반환
+     * @return
+     */
+    public ReportResponse.ReportDto getEmotionReport() {
+        Long userId = getUserIdFromAuthentication();
+        User user = findUserById(userId);
+
+        // 2주동안 나타난 각 감정의 개수 반환
+        LocalDate now = LocalDate.now();
+        LocalDate twoWeekAgo = now.minusDays(14);
+        List<ReportResponse.EmotionDto> emotionDtoList = getEmotionDtoList(twoWeekAgo, now, user);
+
+        // emotion 순서대로 정렬
+        emotionDtoList = emotionDtoList.stream()
+                .sorted(Comparator.comparingInt(ReportResponse.EmotionDto::getOrder))
+                .collect(Collectors.toList());
+
+        return ReportConverter.toReportDto(emotionDtoList);
+    }
+
+    private Long getUserIdFromAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getUserId();
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> new ApiException(ErrorStatus._USER_NOT_FOUND));
+    }
+
+    private List<ReportResponse.EmotionDto> getEmotionDtoList(LocalDate startDate, LocalDate endDate, User user) {
+        return emotionRepository.findEmotionDtoByUser(startDate, endDate, user);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
+        show_sql: true
+        highlight_sql: true
   cloud:
     gcp:
       credentials:


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #16

### 💡 작업내용
- 감정 분석 레포트 기능 구현
- 각 감정 7개의 순서대로 7개의 dto list 반환
- 요청 시점으로부터 14일동안 분석된 각 감정의 개수 반환
- repository로부터 조회되지 않은 감정은 count = 0으로 반환

### 📸 스크린샷(선택)
<img width="996" alt="스크린샷 2024-11-17 오후 6 33 54" src="https://github.com/user-attachments/assets/ebc7ae70-bc3b-4d52-8cc5-046196380a2a">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
