### PR TITLE
[Feature/#20] 감정 분석 레포트 상세 조회 기능 구현

### DIFF
--- a/src/main/java/LearnMate/dev/controller/ReportController.java
+++ b/src/main/java/LearnMate/dev/controller/ReportController.java
@@ -17,4 +17,9 @@ public class ReportController {
     public ApiResponse<ReportResponse.ReportDto> getEmotionReport() {
         return ApiResponse.onSuccessData("감정 분석 레포트 조회 성공", reportService.getEmotionReport());
     }
+
+    @GetMapping("/detail")
+    public ApiResponse<ReportResponse.ReportDetailDto> getEmotionDetailReport() {
+        return ApiResponse.onSuccessData("감정 분석 상세 레포트 조회 성공", reportService.getEmotionDetailReport());
+    }
 }

--- a/src/main/java/LearnMate/dev/model/converter/ReportConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/ReportConverter.java
@@ -13,14 +13,26 @@ public class ReportConverter {
                 .count(emotionDto.getCount())
                 .build();
     }
-    public static ReportResponse.ReportDto toReportDto(List<ReportResponse.EmotionDto> emotionDtoList) {
 
-        List<ReportResponse.ReportEmotionDto> reportEmotionDtoList = emotionDtoList.stream()
+    public static List<ReportResponse.ReportEmotionDto> toReportEmotionDtoList(List<ReportResponse.EmotionDto> emotionDtoList) {
+        return emotionDtoList.stream()
                 .map(ReportConverter::toReportEmotionDto)
                 .toList();
+    }
 
+    public static ReportResponse.ReportDto toReportDto(List<ReportResponse.ReportEmotionDto> reportEmotionDtoList) {
         return ReportResponse.ReportDto.builder()
                 .emotionReport(reportEmotionDtoList)
+                .build();
+    }
+
+    public static ReportResponse.ReportDetailDto toReportDetailDto(List<ReportResponse.ReportEmotionDto> reportEmotionDtoList,
+                                                                   List<ReportResponse.EmotionOnDayDto> emotionOnDayDtoList,
+                                                                   List<ReportResponse.EmotionRankDto> emotionRankDtoList) {
+        return ReportResponse.ReportDetailDto.builder()
+                .emotionReport(reportEmotionDtoList)
+                .emotionOnDayList(emotionOnDayDtoList)
+                .emotionRankDtoList(emotionRankDtoList)
                 .build();
     }
 

--- a/src/main/java/LearnMate/dev/model/dto/response/ReportResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/ReportResponse.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class ReportResponse {
@@ -43,9 +45,50 @@ public class ReportResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class EmotionOnDayDto {
+
+        private String emotion;
+        private String emoticon;
+        private String day;
+
+        public EmotionOnDayDto(EmotionSpectrum emotion, LocalDateTime date) {
+            this.emotion = emotion.getValue();
+            this.emoticon = emotion.getEmoticon();
+            this.day = date.format(DateTimeFormatter.ofPattern("MM/dd"));
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class EmotionRankDto {
+
+        private String emotion;
+        private String emoticon;
+        private Long rank;
+
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class ReportDto {
 
         private List<ReportEmotionDto> emotionReport;
+
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ReportDetailDto {
+
+        private List<ReportEmotionDto> emotionReport;
+        private List<EmotionOnDayDto> emotionOnDayList;
+        private List<EmotionRankDto> emotionRankDtoList;
 
     }
 

--- a/src/main/java/LearnMate/dev/repository/EmotionRepository.java
+++ b/src/main/java/LearnMate/dev/repository/EmotionRepository.java
@@ -23,4 +23,16 @@ public interface EmotionRepository extends JpaRepository<Emotion, Long> {
             @Param(value = "startDate") LocalDate startDate,
             @Param(value = "endDate") LocalDate endDate,
             @Param(value = "user") User user);
+
+    @Query("SELECT new LearnMate.dev.model.dto.response.ReportResponse$EmotionOnDayDto(e.emotion, e.createdAt) " +
+            "FROM Emotion e " +
+            "JOIN e.diary d " +
+            "WHERE d.user = :user " +
+            "AND DATE(e.createdAt) >= :startDate " +
+            "AND DATE(e.createdAt) <= :endDate " +
+            "ORDER BY e.createdAt asc ")
+    List<ReportResponse.EmotionOnDayDto> findEmotionOnDayDtoByUser(
+            @Param(value = "startDate") LocalDate startDate,
+            @Param(value = "endDate") LocalDate endDate,
+            @Param(value = "user") User user);
 }

--- a/src/main/java/LearnMate/dev/service/ReportService.java
+++ b/src/main/java/LearnMate/dev/service/ReportService.java
@@ -15,10 +15,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,32 +27,84 @@ public class ReportService {
 
 
     /*
-     * user가 2주동안 겪은 각 감정의 개수를 리스트 형태로 반환
+     * user의 2주동안 나타난 각 감정의 개수를 리스트 형태로 반환
      * @return
      */
     public ReportResponse.ReportDto getEmotionReport() {
         Long userId = getUserIdFromAuthentication();
         User user = findUserById(userId);
 
-        // 2주동안 나타난 각 감정의 개수 반환
         LocalDate now = LocalDate.now();
         LocalDate twoWeekAgo = now.minusDays(14);
-        List<ReportResponse.EmotionDto> emotionDtoList = getEmotionDtoList(twoWeekAgo, now, user);
 
+        // 2주동안 나타난 각 감정의 개수 반환
+        List<ReportResponse.EmotionDto> emotionDtoList = getEmotionDtoList(twoWeekAgo, now, user);
+        List<ReportResponse.ReportEmotionDto> reportEmotionDtoList = ReportConverter.toReportEmotionDtoList(emotionDtoList);
+
+        return ReportConverter.toReportDto(reportEmotionDtoList);
+    }
+
+    /*
+     * user의 2주동안 나타난 각 감정의 개수, 각 날짜에 나타난 감정, 가장 많이 나타난 감정 리스트를 반환
+     * @return
+     */
+    public ReportResponse.ReportDetailDto getEmotionDetailReport() {
+        Long userId = getUserIdFromAuthentication();
+        User user = findUserById(userId);
+
+        LocalDate now = LocalDate.now();
+        LocalDate twoWeekAgo = now.minusDays(14);
+
+        // 각 감정의 개수
+        List<ReportResponse.EmotionDto> emotionDtoList = getEmotionDtoList(twoWeekAgo, now, user);
+        List<ReportResponse.ReportEmotionDto> reportEmotionDtoList = ReportConverter.toReportEmotionDtoList(emotionDtoList);
+
+        // 각 날짜에 나타난 감정
+        List<ReportResponse.EmotionOnDayDto> emotionOnDayDtoList = getEmotionOnDay(twoWeekAgo, now, user);
+
+        // 해당 기간동안 가장 많이 나타난 감정 3개
+        List<ReportResponse.EmotionRankDto> emotionRankDtoList = getEmotionRank(reportEmotionDtoList);
+
+        return ReportConverter.toReportDetailDto(reportEmotionDtoList, emotionOnDayDtoList, emotionRankDtoList);
+    }
+
+    private List<ReportResponse.EmotionDto> getEmotionDtoList(LocalDate startDate, LocalDate endDate, User user) {
+        List<ReportResponse.EmotionDto> emotionDtoList = emotionRepository.findEmotionDtoByUser(startDate, endDate, user);
+        return getDefaultEmotionDtoAndParse(emotionDtoList);
+    }
+
+    private List<ReportResponse.EmotionDto> getDefaultEmotionDtoAndParse(List<ReportResponse.EmotionDto> emotionDtoList) {
         // 각 감정에 대한 결과 emotiondto를 mapping
         Map<EmotionSpectrum, ReportResponse.EmotionDto> emotionDtoMap = emotionDtoList.stream()
                 .collect(Collectors.toMap(ReportResponse.EmotionDto::getEmotionSpectrum, dto -> dto));
 
         // 0개 나타난 emotion dto 추가 및 정렬
-        List<ReportResponse.EmotionDto> completeEmotionList = Arrays.stream(EmotionSpectrum.values())
+        return Arrays.stream(EmotionSpectrum.values())
                 .map(emotionSpectrum -> emotionDtoMap.getOrDefault(
                         emotionSpectrum,
                         new ReportResponse.EmotionDto(emotionSpectrum, 0L) // 기본값으로 초기화된 DTO
                 ))
                 .sorted(Comparator.comparingInt(ReportResponse.EmotionDto::getOrder)) // 정렬
                 .toList();
+    }
 
-        return ReportConverter.toReportDto(completeEmotionList);
+    private List<ReportResponse.EmotionOnDayDto> getEmotionOnDay(LocalDate startDate, LocalDate endDate, User user) {
+        return emotionRepository.findEmotionOnDayDtoByUser(startDate, endDate, user);
+    }
+
+    private List<ReportResponse.EmotionRankDto> getEmotionRank(List<ReportResponse.ReportEmotionDto> emotionDtoList) {
+        AtomicLong rankCounter = new AtomicLong(1);
+
+        return emotionDtoList.stream()
+                // count 기준 내림차순 정렬
+                .sorted(Comparator.comparingLong(ReportResponse.ReportEmotionDto::getCount).reversed())
+                .limit(3) // 상위 3개만 추출
+                .map(dto -> new ReportResponse.EmotionRankDto( // dto 변환
+                        dto.getEmotion(),
+                        dto.getEmoticon(),
+                        rankCounter.getAndIncrement() // 랭크 할당
+                ))
+                .toList();
     }
 
     private Long getUserIdFromAuthentication() {
@@ -65,9 +115,5 @@ public class ReportService {
 
     private User findUserById(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new ApiException(ErrorStatus._USER_NOT_FOUND));
-    }
-
-    private List<ReportResponse.EmotionDto> getEmotionDtoList(LocalDate startDate, LocalDate endDate, User user) {
-        return emotionRepository.findEmotionDtoByUser(startDate, endDate, user);
     }
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #20 

### 💡 작업내용
- 주간 감정 분석 레포트 상세 조회 기능 구현
- 해당 기간(2주)동안 나타난 각 감정의 개수 반환
- 각 날짜에 나타난 감정 정보 반환
  - 날짜 오름차순 정렬
- 해당 기간동안 가장 많이 나타난 감정 3가지 랭킹 조회 
  - `AtomicLong rankCounter = new AtomicLong(1);` 사용
  -  `getAndIncrement()` 를 통해 1, 2, 3등 순위 부여 

### 📸 스크린샷(선택)
<img width="534" alt="스크린샷 2024-11-17 오후 8 00 45" src="https://github.com/user-attachments/assets/18ce11f6-550f-425a-bb93-68670ee450b3">

<img width="935" alt="스크린샷 2024-11-17 오후 7 56 04" src="https://github.com/user-attachments/assets/78b2c902-37a6-42c4-8ddd-e449b331e2fb">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
