### PR TITLE
[Feature/#19] 감정 캘린더 조회 기능 구현

### DIFF
--- a/src/main/java/LearnMate/dev/controller/DiaryController.java
+++ b/src/main/java/LearnMate/dev/controller/DiaryController.java
@@ -5,6 +5,7 @@ import LearnMate.dev.model.dto.request.DiaryAnalysisRequest;
 import LearnMate.dev.model.dto.request.DiaryPatchRequest;
 import LearnMate.dev.model.dto.request.DiaryPostRequest;
 import LearnMate.dev.model.dto.response.DiaryAnalysisResponse;
+import LearnMate.dev.model.dto.response.DiaryCalendarResponse;
 import LearnMate.dev.model.dto.response.DiaryDetailResponse;
 import LearnMate.dev.service.DiaryService;
 import jakarta.validation.Valid;
@@ -42,5 +43,10 @@ public class DiaryController {
     @GetMapping("/{diaryId}")
     public ApiResponse<DiaryDetailResponse> getDiaryDetail( @PathVariable(value = "diaryId") Long diaryId) {
         return ApiResponse.onSuccessData("일기 상세 조회 성공", diaryService.getDiaryDetail(diaryId));
+    }
+
+    @GetMapping("/calendar")
+    public ApiResponse<DiaryCalendarResponse.DiaryCalendarDto> getDiaryCalendar() {
+        return ApiResponse.onSuccessData("캘린더 조회 성공", diaryService.getDiaryCalendar());
     }
 }

--- a/src/main/java/LearnMate/dev/controller/DiaryController.java
+++ b/src/main/java/LearnMate/dev/controller/DiaryController.java
@@ -10,7 +10,10 @@ import LearnMate.dev.model.dto.response.DiaryDetailResponse;
 import LearnMate.dev.service.DiaryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,7 +49,10 @@ public class DiaryController {
     }
 
     @GetMapping("/calendar")
-    public ApiResponse<DiaryCalendarResponse.DiaryCalendarDto> getDiaryCalendar() {
-        return ApiResponse.onSuccessData("캘린더 조회 성공", diaryService.getDiaryCalendar());
+    public ApiResponse<DiaryCalendarResponse.DiaryCalendarDto> getDiaryCalendar(
+            @RequestParam(value = "date")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        return ApiResponse.onSuccessData("캘린더 조회 성공", diaryService.getDiaryCalendar(date));
     }
 }

--- a/src/main/java/LearnMate/dev/controller/UserController.java
+++ b/src/main/java/LearnMate/dev/controller/UserController.java
@@ -37,7 +37,7 @@ public class UserController {
     }
 
     @GetMapping("/home")
-    public ApiResponse<HomeResponse.HomeDto> getHome() {
+    public ApiResponse<HomeResponse> getHome() {
         return ApiResponse.onSuccessData("홈 화면 조회 성공", userService.getHome());
     }
 

--- a/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
@@ -1,11 +1,14 @@
 package LearnMate.dev.model.converter;
 
 import LearnMate.dev.model.dto.response.DiaryAnalysisResponse;
+import LearnMate.dev.model.dto.response.DiaryCalendarResponse;
 import LearnMate.dev.model.dto.response.DiaryDetailResponse;
 import LearnMate.dev.model.entity.ActionTip;
 import LearnMate.dev.model.entity.Diary;
 import LearnMate.dev.model.entity.Emotion;
 import LearnMate.dev.model.entity.User;
+
+import java.util.List;
 
 public class DiaryConverter {
 
@@ -32,6 +35,12 @@ public class DiaryConverter {
         return DiaryAnalysisResponse.builder()
                 .emotionScore(score)
                 .actionTip(actionTip)
+                .build();
+    }
+
+    public static DiaryCalendarResponse.DiaryCalendarDto toDiaryCalendarResponse(List<DiaryCalendarResponse.DiaryDto> diaryDtoList) {
+        return DiaryCalendarResponse.DiaryCalendarDto.builder()
+                .diaryCalendar(diaryDtoList)
                 .build();
     }
 

--- a/src/main/java/LearnMate/dev/model/converter/HomeConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/HomeConverter.java
@@ -5,8 +5,8 @@ import LearnMate.dev.model.entity.Diary;
 import LearnMate.dev.model.entity.Plan;
 
 public class HomeConverter {
-    public static HomeResponse.HomeDto toHomeDto(Diary diary, Plan plan) {
-        return HomeResponse.HomeDto.builder()
+    public static HomeResponse toHomeResponse(Diary diary, Plan plan) {
+        return HomeResponse.builder()
                 .diaryId(diary == null ? null : diary.getId())
                 .emoticon(diary == null ? null : diary.getEmotion().getEmotion().getEmoticon())
                 .todoId(plan == null ? null : plan.getId())

--- a/src/main/java/LearnMate/dev/model/dto/response/DiaryCalendarResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/DiaryCalendarResponse.java
@@ -1,0 +1,43 @@
+package LearnMate.dev.model.dto.response;
+
+import LearnMate.dev.model.enums.EmotionSpectrum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class DiaryCalendarResponse {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DiaryDto {
+
+        private Long diaryId;
+        private String date;
+        private String emoticon;
+
+        public DiaryDto(Long diaryId, LocalDateTime date, EmotionSpectrum emoticon) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+
+            this.diaryId = diaryId;
+            this.date = date.format(formatter);
+            this.emoticon = emoticon.getEmoticon();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DiaryCalendarDto {
+
+        private List<DiaryDto> diaryCalendar;
+
+    }
+}

--- a/src/main/java/LearnMate/dev/model/dto/response/DiaryCalendarResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/DiaryCalendarResponse.java
@@ -23,7 +23,7 @@ public class DiaryCalendarResponse {
         private String emoticon;
 
         public DiaryDto(Long diaryId, LocalDateTime date, EmotionSpectrum emoticon) {
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
             this.diaryId = diaryId;
             this.date = date.format(formatter);

--- a/src/main/java/LearnMate/dev/model/dto/response/HomeResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/HomeResponse.java
@@ -5,17 +5,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class HomeResponse {
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class HomeDto {
 
-        private Long diaryId;
-        private String emoticon;
-        private Long todoId;
-        private String todoGuide;
+    private Long diaryId;
+    private String emoticon;
+    private Long todoId;
+    private String todoGuide;
 
-    }
 }

--- a/src/main/java/LearnMate/dev/repository/DiaryRepository.java
+++ b/src/main/java/LearnMate/dev/repository/DiaryRepository.java
@@ -36,10 +36,10 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
             "FROM Diary d " +
             "JOIN d.emotion e " +
             "WHERE d.user.id = :userId " +
-            "AND YEAR(d.createdAt) = YEAR(:now) " +
-            "AND MONTH(d.createdAt) = MONTH(:now) " +
+            "AND YEAR(d.createdAt) = YEAR(:date) " +
+            "AND MONTH(d.createdAt) = MONTH(:date) " +
             "ORDER BY d.createdAt")
     List<DiaryCalendarResponse.DiaryDto> findDiaryCreatedAtMonth(
-            @Param(value = "now") LocalDate now,
+            @Param(value = "date") LocalDate date,
             @Param(value = "userId") Long userId);
 }

--- a/src/main/java/LearnMate/dev/repository/DiaryRepository.java
+++ b/src/main/java/LearnMate/dev/repository/DiaryRepository.java
@@ -1,5 +1,6 @@
 package LearnMate.dev.repository;
 
+import LearnMate.dev.model.dto.response.DiaryCalendarResponse;
 import LearnMate.dev.model.entity.Diary;
 import LearnMate.dev.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
@@ -27,6 +29,17 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
             "WHERE d.user.id = :userId " +
             "AND DATE(d.createdAt) = :now")
     Diary findDiaryCreatedAtNowByUserId(
+            @Param(value = "now") LocalDate now,
+            @Param(value = "userId") Long userId);
+
+    @Query("SELECT new LearnMate.dev.model.dto.response.DiaryCalendarResponse$DiaryDto(d.id, d.createdAt, e.emotion) " +
+            "FROM Diary d " +
+            "JOIN d.emotion e " +
+            "WHERE d.user.id = :userId " +
+            "AND YEAR(d.createdAt) = YEAR(:now) " +
+            "AND MONTH(d.createdAt) = MONTH(:now) " +
+            "ORDER BY d.createdAt")
+    List<DiaryCalendarResponse.DiaryDto> findDiaryCreatedAtMonth(
             @Param(value = "now") LocalDate now,
             @Param(value = "userId") Long userId);
 }

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -165,12 +165,11 @@ public class DiaryService {
      * 해당 월에 나타난 감정 리스트를 날짜와 함께 반환
      * @return
      */
-    public DiaryCalendarResponse.DiaryCalendarDto getDiaryCalendar() {
+    public DiaryCalendarResponse.DiaryCalendarDto getDiaryCalendar(LocalDate date) {
         Long userId = getUserIdFromAuthentication();
 
         // 해당 월에 나타난 감정 리스트
-        LocalDate now = LocalDate.now();
-        List<DiaryCalendarResponse.DiaryDto> diaryDtoList = diaryRepository.findDiaryCreatedAtMonth(now, userId);
+        List<DiaryCalendarResponse.DiaryDto> diaryDtoList = diaryRepository.findDiaryCreatedAtMonth(date, userId);
 
         return DiaryConverter.toDiaryCalendarResponse(diaryDtoList);
     }

--- a/src/main/java/LearnMate/dev/service/UserService.java
+++ b/src/main/java/LearnMate/dev/service/UserService.java
@@ -79,13 +79,13 @@ public class UserService {
      * user의 홈 화면을 조회 : 당일 작성된 Diary와 가장 최근에 작성된 TodoGuide 정보를 반환
      * @return
      */
-    public HomeResponse.HomeDto getHome() {
+    public HomeResponse getHome() {
         Long userId = getUserIdFromAuthentication();
 
         Diary diary = findRecentDiaryByUserId(userId);
         Plan plan = findRecentPlanByUserId(userId);
 
-        return HomeConverter.toHomeDto(diary, plan);
+        return HomeConverter.toHomeResponse(diary, plan);
     }
 
     private Plan findRecentPlanByUserId(Long userId) {


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #19 

### 💡 작업내용
- 감정 캘린더 조회 기능 구현
- `date` parameter으로 날짜 입력 시 해당 월에 나타난 감정 리스트 반환
- `yyyy-MM-dd` format 사용

### 📸 스크린샷(선택)
<img width="595" alt="스크린샷 2024-12-01 오후 10 47 25" src="https://github.com/user-attachments/assets/f8ac19e7-dfb9-4d92-baf2-a50356cd993d">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
