### PR TITLE
[Feature/#30] 칭찬 카드 기능 수정

### DIFF
--- a/src/main/java/LearnMate/dev/common/ErrorStatus.java
+++ b/src/main/java/LearnMate/dev/common/ErrorStatus.java
@@ -53,6 +53,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // ComplimentCard
     _COMPLIMENT_CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPLIMENT404", "해당 칭찬카드를 찾을 수 없습니다."),
+    _INVALID_COMPLIMENT_KEYWORD(HttpStatus.INTERNAL_SERVER_ERROR, "COMPLIMENT500", "칭찬 키워드 분석 중 오류가 발생했습니다.")
     ;
 
 

--- a/src/main/java/LearnMate/dev/common/ErrorStatus.java
+++ b/src/main/java/LearnMate/dev/common/ErrorStatus.java
@@ -53,8 +53,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // ComplimentCard
     _COMPLIMENT_CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "COMPLIMENT404", "해당 칭찬카드를 찾을 수 없습니다."),
-    _INVALID_COMPLIMENT_KEYWORD(HttpStatus.INTERNAL_SERVER_ERROR, "COMPLIMENT500", "칭찬 키워드 분석 중 오류가 발생했습니다.")
-    ;
+    _INVALID_COMPLIMENT_KEYWORD(HttpStatus.INTERNAL_SERVER_ERROR, "COMPLIMENT500", "칭찬 키워드 분석 중 오류가 발생했습니다."),
+    _USER_FORBIDDEN_COMPLIMENT_CARD(HttpStatus.FORBIDDEN, "COMPLIMENT403", "칭찬카드에 접근 권한이 없습니다.")
+            ;
 
 
 

--- a/src/main/java/LearnMate/dev/controller/ComplimentCardController.java
+++ b/src/main/java/LearnMate/dev/controller/ComplimentCardController.java
@@ -3,6 +3,7 @@ package LearnMate.dev.controller;
 import LearnMate.dev.common.ApiResponse;
 import LearnMate.dev.model.dto.response.ComplimentCardListResponse;
 import LearnMate.dev.model.dto.response.ComplimentCardResponse;
+import LearnMate.dev.model.dto.response.DiarySimpleResponse;
 import LearnMate.dev.service.ComplimentCardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -18,14 +19,20 @@ public class ComplimentCardController {
 
     @GetMapping
     public ApiResponse<List<ComplimentCardListResponse>> getComplimentCardsList() {
-        return ApiResponse.onSuccessData("칭찬카드 리스트 조회", complimentCardService.getComplimentCards());
+        return ApiResponse.onSuccessData("칭찬카드 리스트 조회 성공", complimentCardService.getComplimentCards());
     }
 
     @GetMapping("/{complimentId}/detail")
     public ApiResponse<ComplimentCardResponse> getComplimentCardDetail(@PathVariable("complimentId") Long complimentId) {
 
-        return ApiResponse.onSuccessData("칭찬카드 상세 조회", complimentCardService.getComplimentCardDetail(complimentId));
+        return ApiResponse.onSuccessData("칭찬카드 상세 조회 성공", complimentCardService.getComplimentCardDetail(complimentId));
 
     }
 
+    @GetMapping("/{complimentId}/diaries")
+    public ApiResponse<List<DiarySimpleResponse>> getComplimentCardDiaries(@PathVariable("complimentId") Long complimentId) {
+
+        return ApiResponse.onSuccessData("칭찬카드 관련 일기 조회 성공", complimentCardService.getComplimentCardDiaries(complimentId));
+
+    }
 }

--- a/src/main/java/LearnMate/dev/controller/ComplimentCardController.java
+++ b/src/main/java/LearnMate/dev/controller/ComplimentCardController.java
@@ -5,10 +5,7 @@ import LearnMate.dev.model.dto.response.ComplimentCardListResponse;
 import LearnMate.dev.model.dto.response.ComplimentCardResponse;
 import LearnMate.dev.service.ComplimentCardService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,8 +21,8 @@ public class ComplimentCardController {
         return ApiResponse.onSuccessData("칭찬카드 리스트 조회", complimentCardService.getComplimentCards());
     }
 
-    @GetMapping("detail")
-    public ApiResponse<ComplimentCardResponse> getComplimentCardDetail(@RequestParam("complimentId") Long complimentId) {
+    @GetMapping("/{complimentId}/detail")
+    public ApiResponse<ComplimentCardResponse> getComplimentCardDetail(@PathVariable("complimentId") Long complimentId) {
 
         return ApiResponse.onSuccessData("칭찬카드 상세 조회", complimentCardService.getComplimentCardDetail(complimentId));
 

--- a/src/main/java/LearnMate/dev/model/converter/ComplimentCardConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/ComplimentCardConverter.java
@@ -3,15 +3,17 @@ package LearnMate.dev.model.converter;
 import LearnMate.dev.model.dto.response.ComplimentCardListResponse;
 import LearnMate.dev.model.dto.response.ComplimentCardResponse;
 import LearnMate.dev.model.entity.ComplimentCard;
+import LearnMate.dev.model.entity.User;
 import LearnMate.dev.model.enums.ComplimentKeyword;
 
 import java.util.List;
 
 public class ComplimentCardConverter {
 
-    public static ComplimentCard toComplimentCard(ComplimentKeyword keyword) {
+    public static ComplimentCard toComplimentCard(ComplimentKeyword keyword, User user) {
         return ComplimentCard.builder()
                 .keyword(keyword)
+                .user(user)
                 .build();
     }
 
@@ -20,8 +22,17 @@ public class ComplimentCardConverter {
         return complimentCards.stream()
                 .map(complimentCard -> ComplimentCardListResponse.builder()
                         .complimentId(complimentCard.getId())
+                        .complimentKeyword(complimentCard.getKeyword().getValue())
                         .build())
                 .toList();
 
+    }
+
+    public static ComplimentCardResponse toComplimentCardResponse(ComplimentCard complimentCard) {
+        return ComplimentCardResponse.builder()
+                .complimentId(complimentCard.getId())
+                .complimentKeyword(complimentCard.getKeyword().getValue())
+                .complimentContent(complimentCard.getKeyword().getContent())
+                .build();
     }
 }

--- a/src/main/java/LearnMate/dev/model/converter/ComplimentCardConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/ComplimentCardConverter.java
@@ -3,21 +3,15 @@ package LearnMate.dev.model.converter;
 import LearnMate.dev.model.dto.response.ComplimentCardListResponse;
 import LearnMate.dev.model.dto.response.ComplimentCardResponse;
 import LearnMate.dev.model.entity.ComplimentCard;
-import LearnMate.dev.model.entity.User;
+import LearnMate.dev.model.enums.ComplimentKeyword;
 
 import java.util.List;
 
 public class ComplimentCardConverter {
 
-    public static ComplimentCard toComplimentCard(User user,
-                                                  String complimentTitle,
-                                                  String complimentContent,
-                                                  Long diaryId) {
+    public static ComplimentCard toComplimentCard(ComplimentKeyword keyword) {
         return ComplimentCard.builder()
-                .user(user)
-                .title(complimentTitle)
-                .content(complimentContent)
-                .diaryId(diaryId)
+                .keyword(keyword)
                 .build();
     }
 
@@ -26,19 +20,8 @@ public class ComplimentCardConverter {
         return complimentCards.stream()
                 .map(complimentCard -> ComplimentCardListResponse.builder()
                         .complimentId(complimentCard.getId())
-                        .complimentTitle(complimentCard.getTitle())
-                        .complimentContent(complimentCard.getContent())
                         .build())
                 .toList();
 
     }
-
-    public static ComplimentCardResponse toComplimentCardResponse(ComplimentCard complimentCard) {
-        return ComplimentCardResponse.builder()
-                .complimentTitle(complimentCard.getTitle())
-                .complimentContent(complimentCard.getContent())
-                .diaryId(complimentCard.getDiaryId())
-                .build();
-    }
-
 }

--- a/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
@@ -3,6 +3,7 @@ package LearnMate.dev.model.converter;
 import LearnMate.dev.model.dto.response.DiaryAnalysisResponse;
 import LearnMate.dev.model.dto.response.DiaryCalendarResponse;
 import LearnMate.dev.model.dto.response.DiaryDetailResponse;
+import LearnMate.dev.model.dto.response.DiarySimpleResponse;
 import LearnMate.dev.model.entity.*;
 
 import java.util.List;
@@ -40,6 +41,15 @@ public class DiaryConverter {
     public static DiaryCalendarResponse.DiaryCalendarDto toDiaryCalendarResponse(List<DiaryCalendarResponse.DiaryDto> diaryDtoList) {
         return DiaryCalendarResponse.DiaryCalendarDto.builder()
                 .diaryCalendar(diaryDtoList)
+                .build();
+    }
+
+    public static DiarySimpleResponse toDiarySimpleResponse(Diary diary) {
+        return DiarySimpleResponse.builder()
+                .diaryId(diary.getId())
+                .date(diary.getCreatedAtFormatted())
+                .emoticon(diary.getEmotion().getEmotion().getValue())
+                .content(diary.getContent().substring(0, 50)) // 50자만 반환
                 .build();
     }
 

--- a/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
+++ b/src/main/java/LearnMate/dev/model/converter/DiaryConverter.java
@@ -3,21 +3,20 @@ package LearnMate.dev.model.converter;
 import LearnMate.dev.model.dto.response.DiaryAnalysisResponse;
 import LearnMate.dev.model.dto.response.DiaryCalendarResponse;
 import LearnMate.dev.model.dto.response.DiaryDetailResponse;
-import LearnMate.dev.model.entity.ActionTip;
-import LearnMate.dev.model.entity.Diary;
-import LearnMate.dev.model.entity.Emotion;
-import LearnMate.dev.model.entity.User;
+import LearnMate.dev.model.entity.*;
 
 import java.util.List;
 
 public class DiaryConverter {
 
-    public static Diary toDiary(String content, User user, Emotion emotion, ActionTip actionTip) {
+    public static Diary toDiary(String content, User user, Emotion emotion,
+                                ActionTip actionTip, ComplimentCard complimentCard) {
         return Diary.builder()
                 .content(content)
                 .user(user)
                 .emotion(emotion)
                 .actionTip(actionTip)
+                .complimentCard(complimentCard)
                 .build();
     }
 

--- a/src/main/java/LearnMate/dev/model/dto/response/ComplimentCardListResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/ComplimentCardListResponse.java
@@ -1,12 +1,9 @@
 package LearnMate.dev.model.dto.response;
 
-import LearnMate.dev.model.entity.ComplimentCard;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -15,7 +12,6 @@ import java.util.List;
 public class ComplimentCardListResponse {
 
     private Long complimentId;
-    private String complimentTitle;
-    private String complimentContent;
+    private String complimentKeyword;
 
 }

--- a/src/main/java/LearnMate/dev/model/dto/response/ComplimentCardResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/ComplimentCardResponse.java
@@ -11,8 +11,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ComplimentCardResponse {
 
-    private String complimentTitle;
+    private Long complimentId;
+    private String complimentKeyword;
     private String complimentContent;
-    private Long diaryId;
 
 }

--- a/src/main/java/LearnMate/dev/model/dto/response/DiarySimpleResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/DiarySimpleResponse.java
@@ -1,0 +1,31 @@
+package LearnMate.dev.model.dto.response;
+
+import LearnMate.dev.model.enums.EmotionSpectrum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DiarySimpleResponse {
+
+    private Long diaryId;
+    private String date;
+    private String emoticon;
+    private String content;
+
+    public DiarySimpleResponse(Long diaryId, LocalDateTime date, EmotionSpectrum emoticon, String content) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        this.diaryId = diaryId;
+        this.date = date.format(formatter);
+        this.emoticon = emoticon.getEmoticon();
+        this.content = content;
+    }
+}

--- a/src/main/java/LearnMate/dev/model/entity/ComplimentCard.java
+++ b/src/main/java/LearnMate/dev/model/entity/ComplimentCard.java
@@ -22,4 +22,8 @@ public class ComplimentCard extends BaseTimeEntity {
     @Column(name = "keyword", nullable = false)
     private ComplimentKeyword keyword;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
 }

--- a/src/main/java/LearnMate/dev/model/entity/ComplimentCard.java
+++ b/src/main/java/LearnMate/dev/model/entity/ComplimentCard.java
@@ -1,7 +1,7 @@
 package LearnMate.dev.model.entity;
 
-
 import LearnMate.dev.common.BaseTimeEntity;
+import LearnMate.dev.model.enums.ComplimentKeyword;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -18,17 +18,8 @@ public class ComplimentCard extends BaseTimeEntity {
     @Column(name = "compliments_id")
     private Long id;
 
-    @Column(name = "compliments_title", nullable = false)
-    private String title;
-
-    @Column(name = "compliments_content", nullable = false)
-    private String content;
-
-    @Column(name = "compliments_diary_id", nullable = false)
-    private Long diaryId;
-
-    @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "keyword", nullable = false)
+    private ComplimentKeyword keyword;
 
 }

--- a/src/main/java/LearnMate/dev/model/entity/Diary.java
+++ b/src/main/java/LearnMate/dev/model/entity/Diary.java
@@ -28,6 +28,10 @@ public class Diary extends BaseTimeEntity {
     @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL, orphanRemoval = true)
     private ActionTip actionTip;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "compliments_id")
+    private ComplimentCard complimentCard;
+
     public void updateContent(String content) {
         if (!content.isEmpty()) {
             this.content = content;

--- a/src/main/java/LearnMate/dev/model/enums/ComplimentKeyword.java
+++ b/src/main/java/LearnMate/dev/model/enums/ComplimentKeyword.java
@@ -1,0 +1,28 @@
+package LearnMate.dev.model.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ComplimentKeyword {
+
+    EFFORT("노력", "노력 Content"), PASSION("열정", "열정 Content"),
+    TRUTH("성실", "성실 Content"), RESPONSIBILITY("책임감", "책임감 Content"),
+    CREATIVITY("창의력", "창의력 Content"), DELICATE("섬세함", "섬세함 Content"),
+    COURAGE("용기", "용기 Content"), KINDNESS("친절함", "친절함 Content"),
+    CONSIDERATION("배려심", "배려심 Content"), AFFIRMATION("긍정", "긍정 Content")
+    ;
+
+    private final String value;
+    private final String content;
+
+    public static ComplimentKeyword getKeyword(String value){
+        for (ComplimentKeyword keyword : ComplimentKeyword.values()) {
+            if (keyword.getValue().equals(value)) {
+                return keyword;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/LearnMate/dev/model/enums/ComplimentKeyword.java
+++ b/src/main/java/LearnMate/dev/model/enums/ComplimentKeyword.java
@@ -7,11 +7,16 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ComplimentKeyword {
 
-    EFFORT("노력", "노력 Content"), PASSION("열정", "열정 Content"),
-    TRUTH("성실", "성실 Content"), RESPONSIBILITY("책임감", "책임감 Content"),
-    CREATIVITY("창의력", "창의력 Content"), DELICATE("섬세함", "섬세함 Content"),
-    COURAGE("용기", "용기 Content"), KINDNESS("친절함", "친절함 Content"),
-    CONSIDERATION("배려심", "배려심 Content"), AFFIRMATION("긍정", "긍정 Content"),
+    EFFORT("노력", "어려운 상황에서도 포기하지 않고 끝까지 해내는 당신의 노력은 정말 대단해요. 계속 응원할게요!"),
+    PASSION("열정", "당신의 뜨거운 열정이 더 큰 가능성을 만들어가고 있어요. 앞으로도 그 열정 잃지 않길 바라요!”"),
+    TRUTH("성실", "늘 최선을 다하고 성실하게 임하는 모습에서 큰 감동을 받습니다. 그 꾸준한 노력이 분명 큰 성과로 이어질 거예요.”"),
+    RESPONSIBILITY("책임감", "맡은 일을 끝까지 책임지는 모습이 정말 믿음직스럽고 멋져요. 당신 덕분에 모두가 안심할 수 있습니다."),
+    CREATIVITY("창의력", "당신의 독창적인 생각 덕분에 주변이 더욱 다채롭고 풍요로워집니다. 앞으로도 그 상상력을 마음껏 펼치길 바라요!"),
+    DELICATE("섬세함", "작은 부분까지도 세심히 신경 쓰는 당신의 섬세함 덕분에 모두가 더 편안함을 느낍니다. 그 따뜻한 마음에 감사드려요!”"),
+    COURAGE("용기", "어려운 순간에도 용기를 잃지 않고 앞으로 나아가는 모습이 정말 멋져요. 당신의 도전, 항상 응원할게요!"),
+    KINDNESS("친절함", "언제나 따뜻한 말과 행동으로 주변 사람들을 행복하게 해주는 당신의 친절함이 정말 아름다워요. 당신 덕분에 모두가 더 밝아지고 행복해져요."),
+    CONSIDERATION("배려심", "당신의 세심한 배려 덕분에 모두가 더 행복하고 편안해졌어요. 당신과 함께하는 시간이 정말 따뜻합니다.”"),
+    AFFIRMATION("긍정", "긍정적인 태도로 모든 걸 더 나은 방향으로 이끄는 당신 덕분에 모두가 힘을 얻습니다. 앞으로도 밝고 긍정적인 에너지로 주변을 환하게 만들어주세요!"),
     NO_KEYWORD("NO_KEYWORD", "X")
     ;
 

--- a/src/main/java/LearnMate/dev/model/enums/ComplimentKeyword.java
+++ b/src/main/java/LearnMate/dev/model/enums/ComplimentKeyword.java
@@ -11,7 +11,8 @@ public enum ComplimentKeyword {
     TRUTH("성실", "성실 Content"), RESPONSIBILITY("책임감", "책임감 Content"),
     CREATIVITY("창의력", "창의력 Content"), DELICATE("섬세함", "섬세함 Content"),
     COURAGE("용기", "용기 Content"), KINDNESS("친절함", "친절함 Content"),
-    CONSIDERATION("배려심", "배려심 Content"), AFFIRMATION("긍정", "긍정 Content")
+    CONSIDERATION("배려심", "배려심 Content"), AFFIRMATION("긍정", "긍정 Content"),
+    NO_KEYWORD("NO_KEYWORD", "X")
     ;
 
     private final String value;

--- a/src/main/java/LearnMate/dev/repository/ComplimentCardRepository.java
+++ b/src/main/java/LearnMate/dev/repository/ComplimentCardRepository.java
@@ -1,15 +1,19 @@
 package LearnMate.dev.repository;
 
 import LearnMate.dev.model.entity.ComplimentCard;
+import LearnMate.dev.model.enums.ComplimentKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ComplimentCardRepository extends JpaRepository<ComplimentCard, Long> {
 
     List<ComplimentCard> findAllByUserId(Long userId);
+
+    Optional<ComplimentCard> findByKeyword(ComplimentKeyword keyword);
 
 }

--- a/src/main/java/LearnMate/dev/repository/ComplimentCardRepository.java
+++ b/src/main/java/LearnMate/dev/repository/ComplimentCardRepository.java
@@ -1,8 +1,10 @@
 package LearnMate.dev.repository;
 
 import LearnMate.dev.model.entity.ComplimentCard;
+import LearnMate.dev.model.entity.User;
 import LearnMate.dev.model.enums.ComplimentKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -12,8 +14,13 @@ import java.util.Optional;
 @Repository
 public interface ComplimentCardRepository extends JpaRepository<ComplimentCard, Long> {
 
-    List<ComplimentCard> findAllByUserId(Long userId);
+    @Query(value = "SELECT c " +
+            "FROM ComplimentCard c " +
+            "WHERE c.user.id = :userId " +
+            "AND c.keyword != 'NO_KEYWORD' " +
+            "ORDER BY c.createdAt desc")
+    List<ComplimentCard> findAllByUserId(@Param(value = "userId") Long userId);
 
-    Optional<ComplimentCard> findByKeyword(ComplimentKeyword keyword);
+    Optional<ComplimentCard> findByKeywordAndUser(ComplimentKeyword keyword, User user);
 
 }

--- a/src/main/java/LearnMate/dev/repository/DiaryRepository.java
+++ b/src/main/java/LearnMate/dev/repository/DiaryRepository.java
@@ -1,6 +1,8 @@
 package LearnMate.dev.repository;
 
 import LearnMate.dev.model.dto.response.DiaryCalendarResponse;
+import LearnMate.dev.model.dto.response.DiarySimpleResponse;
+import LearnMate.dev.model.entity.ComplimentCard;
 import LearnMate.dev.model.entity.Diary;
 import LearnMate.dev.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -42,4 +44,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<DiaryCalendarResponse.DiaryDto> findDiaryCreatedAtMonth(
             @Param(value = "date") LocalDate date,
             @Param(value = "userId") Long userId);
+
+
+    @Query("SELECT new LearnMate.dev.model.dto.response.DiarySimpleResponse(d.id, d.createdAt, e.emotion, d.content) " +
+            "FROM Diary d " +
+            "JOIN d.emotion e " +
+            "WHERE d.complimentCard = :complimentCard " +
+            "ORDER BY d.createdAt desc")
+    List<DiarySimpleResponse> findDiaryByComplimentCard(
+        @Param(value = "complimentCard") ComplimentCard complimentCard
+    );
 }

--- a/src/main/java/LearnMate/dev/service/ComplimentCardService.java
+++ b/src/main/java/LearnMate/dev/service/ComplimentCardService.java
@@ -5,10 +5,12 @@ import LearnMate.dev.common.exception.ApiException;
 import LearnMate.dev.model.converter.ComplimentCardConverter;
 import LearnMate.dev.model.dto.response.ComplimentCardListResponse;
 import LearnMate.dev.model.dto.response.ComplimentCardResponse;
+import LearnMate.dev.model.dto.response.DiarySimpleResponse;
 import LearnMate.dev.model.entity.ComplimentCard;
 import LearnMate.dev.model.entity.User;
 import LearnMate.dev.model.enums.ComplimentKeyword;
 import LearnMate.dev.repository.ComplimentCardRepository;
+import LearnMate.dev.repository.DiaryRepository;
 import LearnMate.dev.security.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -24,6 +26,7 @@ import java.util.List;
 public class ComplimentCardService {
 
     private final ComplimentCardRepository complimentCardRepository;
+    private final DiaryRepository diaryRepository;
     private final OpenAIService openAIService;
 
 
@@ -86,7 +89,15 @@ public class ComplimentCardService {
     }
 
     // 칭찬카드 관련 일기 리스트 조회
+    public List<DiarySimpleResponse> getComplimentCardDiaries(Long complimentId) {
 
+        Long userId = getUserIdFromAuthentication();
+        ComplimentCard complimentCard = findComplimentCardById(complimentId);
+
+        validIsUserAuthorizedForComplimentCard(userId, complimentCard);
+
+        return diaryRepository.findDiaryByComplimentCard(complimentCard);
+    }
 
     private Long getUserIdFromAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -50,7 +50,7 @@ public class DiaryService {
     public DiaryAnalysisResponse analyzeDiary(DiaryAnalysisRequest request) {
         Long userId = getUserIdFromAuthentication();
         User user = findUserById(userId);
-        validIsUserPostDiary(user);
+//        validIsUserPostDiary(user);
 
         // content 길이 검사
         String content = request.getContent();
@@ -77,7 +77,7 @@ public class DiaryService {
 
         Long userId = getUserIdFromAuthentication();
         User user = findUserById(userId);
-        validIsUserPostDiary(user);
+//        validIsUserPostDiary(user);
 
         // content 길이 검사
         validContentLength(request.getContent());

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -86,7 +86,7 @@ public class DiaryService {
         EmotionSpectrum emotionSpectrum = validEmotion(request.getScore(), request.getEmotion());
 
         // 칭찬 카드 생성 및 조회
-        ComplimentCard complimentCard = complimentCardService.createComplimentCard(request.getContent());
+        ComplimentCard complimentCard = complimentCardService.createComplimentCard(request.getContent(), user);
 
         // 객체 생성 및 연관관계 설정
         Diary diary = createDiary(user, request, emotionSpectrum, complimentCard);

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -35,10 +35,11 @@ public class DiaryService {
 
     private final UserRepository userRepository;
     private final DiaryRepository diaryRepository;
-    private final ComplimentCardRepository complimentCardRepository;
 
     private final NaturalLanguageService naturalLanguageService;
     private final OpenAIService openAIService;
+    private final ComplimentCardService complimentCardService;
+
 
     /*
      * 유저의 일기 내용을 기반으로 감정을 분석하고 행동 요령을 제안함
@@ -84,22 +85,22 @@ public class DiaryService {
         // emotion 정보 검사
         EmotionSpectrum emotionSpectrum = validEmotion(request.getScore(), request.getEmotion());
 
-        // 객체 생성 및 연관관계 설정
-        Diary diary = createDiary(user, request, emotionSpectrum);
-        diaryRepository.save(diary);
+        // 칭찬 카드 생성 및 조회
+        ComplimentCard complimentCard = complimentCardService.createComplimentCard(request.getContent());
 
-        ComplimentCard complimentCard = createComplimentCard(user, request.getContent(), diary.getId());
-        complimentCardRepository.save(complimentCard);
+        // 객체 생성 및 연관관계 설정
+        Diary diary = createDiary(user, request, emotionSpectrum, complimentCard);
+        diaryRepository.save(diary);
 
         return DiaryConverter.toDiaryDetailResponse(diary);
 
     }
 
     @Transactional
-    public Diary createDiary(User user, DiaryPostRequest request, EmotionSpectrum emotionSpectrum) {
+    public Diary createDiary(User user, DiaryPostRequest request, EmotionSpectrum emotionSpectrum, ComplimentCard complimentCard) {
         Emotion emotion = EmotionConverter.toEmotion(request.getScore(), emotionSpectrum);
         ActionTip actionTip = ActionTipConverter.toActionTip(request.getActionTip());
-        Diary diary = DiaryConverter.toDiary(request.getContent(), user, emotion, actionTip);
+        Diary diary = DiaryConverter.toDiary(request.getContent(), user, emotion, actionTip, complimentCard);
 
         emotion.updateDiary(diary);
         actionTip.updateDiary(diary);
@@ -179,14 +180,6 @@ public class DiaryService {
         List<DiaryCalendarResponse.DiaryDto> diaryDtoList = diaryRepository.findDiaryCreatedAtMonth(date, userId);
 
         return DiaryConverter.toDiaryCalendarResponse(diaryDtoList);
-    }
-
-    private ComplimentCard createComplimentCard(User user, String content, Long diaryId) {
-
-        String complimentContent = openAIService.getComplimentCardContent(content);
-        String complimentTitle = openAIService.getComplimentCardTitle(complimentContent);
-
-        return ComplimentCardConverter.toComplimentCard(user, complimentTitle, complimentContent, diaryId);
     }
 
     private void validIsUserPostDiary(User user) {

--- a/src/main/java/LearnMate/dev/service/OpenAIService.java
+++ b/src/main/java/LearnMate/dev/service/OpenAIService.java
@@ -13,8 +13,7 @@ import java.util.concurrent.CompletableFuture;
 public class OpenAIService {
     private final String ACTION_TIP_PROMPT = ResourceLoader.getResourceContent("action-tip-prompt.txt");
     private final String TODO_GUIDE_PROMPT = ResourceLoader.getResourceContent("todo-guide-prompt.txt");
-    private final String COMPLIMENT_CARD_TITLE_PROMPT = ResourceLoader.getResourceContent("compliment-card-title-prompt.txt");
-    private final String COMPLIMENT_CARD_CONTENT_PROMPT = ResourceLoader.getResourceContent("compliment-card-content-prompt.txt");
+    private final String COMPLIMENT_CARD_KEYWORD_PROMPT = ResourceLoader.getResourceContent("compliment-card-keyword-prompt.txt");
 
     private final OpenAiChatModel chatModel;
 
@@ -33,15 +32,9 @@ public class OpenAIService {
 
     }
 
-    public String getComplimentCardTitle(String content) {
+    public String getComplimentCard(String content) {
 
-        return chatModel.call(COMPLIMENT_CARD_TITLE_PROMPT + content);
-
-    }
-
-    public String getComplimentCardContent(String content) {
-
-        return chatModel.call(COMPLIMENT_CARD_CONTENT_PROMPT + content);
+        return chatModel.call(COMPLIMENT_CARD_KEYWORD_PROMPT + content);
 
     }
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #30 

### 💡 작업내용
- `complimentKeyword` enum 생성
  - 10가지의 키워드
- 칭찬카드 생성 기능 수정
  - 칭찬 키워드에 부합하지 않는 일기일 시, `NO_KEYWORD` 반환
- 칭찬카드 리스트 조회 기능 수정
- 칭찬카드 상세 조회 기능 수정
- 칭찬카드 관련 일기 리스트 조회 기능 수정
- 일기 하루에 한 개 작성 제한 임시 해제    

### 📸 스크린샷(선택)
<img width="628" alt="스크린샷 2024-12-03 오후 6 32 05" src="https://github.com/user-attachments/assets/71a5dff5-da9a-4b62-82ea-f3c7195a7375">
<img width="579" alt="스크린샷 2024-12-03 오후 6 32 22" src="https://github.com/user-attachments/assets/61468f1e-d382-4324-8114-3caf262b493e">


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
