### PR TITLE
[Feat/#44] 일기 상세 조회 추가 기능 구현

### DIFF
--- a/src/main/java/LearnMate/dev/controller/DiaryController.java
+++ b/src/main/java/LearnMate/dev/controller/DiaryController.java
@@ -9,6 +9,7 @@ import LearnMate.dev.model.dto.response.diary.DiaryCalendarResponse;
 import LearnMate.dev.model.dto.response.diary.DiaryDetailResponse;
 import LearnMate.dev.service.DiaryService;
 import jakarta.validation.Valid;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
@@ -56,6 +57,14 @@ public class DiaryController {
             @PathVariable(value = "diaryId") Long diaryId
     ) {
         return ApiResponse.onSuccessData("일기 상세 조회 성공", diaryService.getDiaryDetail(diaryId));
+    }
+
+    @GetMapping
+    public ApiResponse<DiaryDetailResponse> getDiaryDetailByDate(
+            @RequestParam(value = "date")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        return ApiResponse.onSuccessData("일기 상세 조회 성공", diaryService.getDiaryDetailByDate(date));
     }
 
     @GetMapping("/calendar")

--- a/src/main/java/LearnMate/dev/model/dto/response/diary/DiaryCalendarResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/diary/DiaryCalendarResponse.java
@@ -18,14 +18,12 @@ public class DiaryCalendarResponse {
     @NoArgsConstructor
     public static class DiaryDto {
 
-        private Long diaryId;
         private String date;
         private String emotion;
 
-        public DiaryDto(Long diaryId, LocalDateTime date, EmotionSpectrum emoticon) {
+        public DiaryDto(LocalDateTime date, EmotionSpectrum emoticon) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-            this.diaryId = diaryId;
             this.date = date.format(formatter);
             this.emotion = emoticon.getValue();
         }

--- a/src/main/java/LearnMate/dev/repository/DiaryRepository.java
+++ b/src/main/java/LearnMate/dev/repository/DiaryRepository.java
@@ -57,4 +57,13 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
         @Param(value = "complimentCard") ComplimentCard complimentCard,
         @Param(value = "userId") Long userId
     );
+
+    @Query(value = "SELECT d " +
+            "FROM Diary d " +
+            "JOIN FETCH d.emotion e " +
+            "JOIN FETCH d.actionTip ac " +
+            "WHERE d.user.id = :userId " +
+            "AND DATE(d.createdAt) = :date")
+    List<Diary> findDiaryByCreatedAt(@Param(value = "date") LocalDate date,
+                                     @Param(value = "userId") Long userId);
 }

--- a/src/main/java/LearnMate/dev/repository/DiaryRepository.java
+++ b/src/main/java/LearnMate/dev/repository/DiaryRepository.java
@@ -35,7 +35,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
             @Param(value = "userId") Long userId);
 
 
-    @Query("SELECT new LearnMate.dev.model.dto.response.diary.DiaryCalendarResponse$DiaryDto(d.id, d.createdAt, e.emotion) " +
+    @Query("SELECT new LearnMate.dev.model.dto.response.diary.DiaryCalendarResponse$DiaryDto(d.createdAt, e.emotion) " +
             "FROM Diary d " +
             "JOIN d.emotion e " +
             "WHERE d.user.id = :userId " +

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -182,6 +182,17 @@ public class DiaryService {
     }
 
     /*
+     * 해당 날짜에 작성된 diary의 상세 정보를 반환
+     * @param date
+     * @return
+     */
+    public DiaryDetailResponse getDiaryDetailByDate(LocalDate date) {
+        Long userId = getUserIdFromAuthentication();
+        Diary diary = findDiaryByDate(date, userId);
+        return DiaryConverter.toDiaryDetailResponse(diary);
+    }
+
+    /*
      * 해당 월에 나타난 감정 리스트를 날짜와 함께 반환
      * @return
      */
@@ -233,6 +244,14 @@ public class DiaryService {
     private Diary findDiaryById(Long diaryId) {
         return diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new ApiException(ErrorStatus._DIARY_NOT_FOUND));
+    }
+
+    private Diary findDiaryByDate(LocalDate date, Long userId) {
+        List<Diary> diary = diaryRepository.findDiaryByCreatedAt(date, userId);
+        if (diary.isEmpty())
+            throw new ApiException(ErrorStatus._DIARY_NOT_FOUND);
+
+        return diary.get(0);
     }
 
     private Long getUserIdFromAuthentication() {


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #44 

### 💡 작업내용
- 날짜를 parameter으로 받아 일기 상세 조회
- 캘린더 조회 response -> diaryId 제거


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
