### PR TITLE
[Fix/#46] 존재하지 않는 칭찬 키워드 추출에 대한 예외 처리 추가

### DIFF
--- a/src/main/java/LearnMate/dev/model/dto/response/diary/DiarySimpleResponse.java
+++ b/src/main/java/LearnMate/dev/model/dto/response/diary/DiarySimpleResponse.java
@@ -17,7 +17,7 @@ public class DiarySimpleResponse {
 
     private Long diaryId;
     private String date;
-    private String emoticon;
+    private String emotion;
     private String content;
 
     public DiarySimpleResponse(Long diaryId, LocalDateTime date, EmotionSpectrum emoticon, String content) {
@@ -25,7 +25,7 @@ public class DiarySimpleResponse {
 
         this.diaryId = diaryId;
         this.date = date.format(formatter);
-        this.emoticon = emoticon.getEmoticon();
+        this.emotion = emoticon.getValue();
         this.content = content;
     }
 }

--- a/src/main/java/LearnMate/dev/service/DiaryService.java
+++ b/src/main/java/LearnMate/dev/service/DiaryService.java
@@ -12,6 +12,7 @@ import LearnMate.dev.model.dto.response.diary.DiaryAnalysisResponse;
 import LearnMate.dev.model.dto.response.diary.DiaryCalendarResponse;
 import LearnMate.dev.model.dto.response.diary.DiaryDetailResponse;
 import LearnMate.dev.model.entity.*;
+import LearnMate.dev.model.enums.ComplimentKeyword;
 import LearnMate.dev.model.enums.EmotionSpectrum;
 import LearnMate.dev.repository.DiaryRepository;
 import LearnMate.dev.repository.UserRepository;
@@ -71,6 +72,12 @@ public class DiaryService {
                         Float score = scoreFuture.get();
                         String actionTip = actionTipFuture.get();
                         String compliment = complimentFuture.get();
+
+                        ComplimentKeyword keyword = ComplimentKeyword.getKeyword(compliment);
+                        if (keyword == null) {
+                            keyword = ComplimentKeyword.NO_KEYWORD;
+                        }
+                        compliment = keyword.getValue();
 
                         return DiaryConverter.toDiaryAnalysisResponse(score, actionTip, compliment);
                     } catch (Exception e) {


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #46 

### 💡 작업내용
- 칭찬 키워드에 대한 일기 리스트 조회 기능 response 수정
  - emoticon -> emotion
- 칭찬 키워드 파싱 시, 리스트에 존재하지 않는 키워드를 추출하면 NO_KEYWORD 일괄 반환  


### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)
